### PR TITLE
Fix external links section in mobile nav menu misalignment

### DIFF
--- a/_sass/site.scss
+++ b/_sass/site.scss
@@ -116,7 +116,10 @@ div.trigger > a.page-link {
   nav.site-nav {
     min-width: 30px !important;
     background: #f0d8d5;
+  }
 
+  .site-nav .page-link {
+    padding-right: 20px;
   }
 
   span.menu-icon > svg > path {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5790137/47193043-d91f8000-d31e-11e8-8b88-aa71f82cc12f.png)

After:
![image](https://user-images.githubusercontent.com/5790137/47193024-ba20ee00-d31e-11e8-8362-739668e333aa.png)
